### PR TITLE
Golang 1.8 support

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6.1
+FROM golang:1.8
 
 RUN apt-get update && apt-get install -y upx-ucl libsystemd-dev
 
@@ -9,7 +9,6 @@ RUN wget -nv \
 
 RUN go get github.com/pwaller/goupx
 
-VOLUME /src
 WORKDIR /src
 
 COPY build_environment.sh /

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -38,11 +38,26 @@ then
   fi
 fi
 
-if [[ -e "/var/run/docker.sock"  &&  -e "./Dockerfile" ]];
+dockerArgs=""
+
+if [[ $NO_CACHE == "true" ]];
+then
+  dockerArgs="$dockerArgs --no-cache"
+fi
+
+dockerFile="Dockerfile"
+
+if [[ $DOCKERFILE != "" ]];
+then
+  dockerFile=$DOCKERFILE
+  dockerArgs="$dockerArgs -f $DOCKERFILE"
+fi
+
+if [[ -e "/var/run/docker.sock" && -e "./$dockerFile" ]];
 then
   # Default TAG_NAME to package name if not set explicitly
   tagName=${tagName:-"$name":latest}
 
   # Build the image from the Dockerfile in the package directory
-  docker build -t $tagName .
+  docker build $dockerArgs -t $tagName .
 fi

--- a/builder/build_environment.sh
+++ b/builder/build_environment.sh
@@ -17,4 +17,27 @@ then
   exit 992
 fi
 
-go get -t -d -v ./...
+# Grab just first path listed in GOPATH
+goPath="${GOPATH%%:*}"
+
+# Construct Go package path
+pkgPath="$goPath/src/$pkgName"
+
+# Set-up src directory tree in GOPATH
+mkdir -p "$(dirname "$pkgPath")"
+
+# Link source dir into GOPATH
+ln -sf /src "$pkgPath"
+
+if [ -e "$pkgPath/vendor" ];
+then
+    # Enable vendor experiment
+    export GO15VENDOREXPERIMENT=1
+elif [ -e "$pkgPath/Godeps/_workspace" ];
+then
+  # Add local godeps dir to GOPATH
+  GOPATH=$pkgPath/Godeps/_workspace:$GOPATH
+else
+  # Get all package dependencies
+  go get -t -d -v ./...
+fi

--- a/builder/build_environment.sh
+++ b/builder/build_environment.sh
@@ -31,8 +31,9 @@ ln -sf /src "$pkgPath"
 
 if [ -e "$pkgPath/vendor" ];
 then
-    # Enable vendor experiment
-    export GO15VENDOREXPERIMENT=1
+    # Do nothing
+    # GO15VENDOREXPERIMENT behaviour is default in go 1.7
+    echo "Using vendor packages..."
 elif [ -e "$pkgPath/Godeps/_workspace" ];
 then
   # Add local godeps dir to GOPATH


### PR DESCRIPTION
Updating our golang-builder to go 1.8 as the century link builder is 1.6 currently

I've reverted a change made previously for projects that have subfolders, see https://github.com/CenturyLinkLabs/golang-builder/issues/29

We don't use the Sumologic libraries that the patch was intended for, so I don't see an issue reverting them. This more closely mimics the build behaviour of the CenturyLink image.

Upstream changes from another fork - https://github.com/evenco/golang-builder