### PR TITLE
Golang 1.8 support for test image as well as build

### DIFF
--- a/tester/Dockerfile
+++ b/tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6.1
+FROM golang:1.8
 
 RUN apt-get update && apt-get install -y libsystemd-dev
 

--- a/tester/build_environment.sh
+++ b/tester/build_environment.sh
@@ -17,5 +17,27 @@ then
   exit 992
 fi
 
-# Get all package dependencies
-go get -t -d -v ./...
+# Grab just first path listed in GOPATH
+goPath="${GOPATH%%:*}"
+
+# Construct Go package path
+pkgPath="$goPath/src/$pkgName"
+
+# Set-up src directory tree in GOPATH
+mkdir -p "$(dirname "$pkgPath")"
+
+# Link source dir into GOPATH
+ln -sf /src "$pkgPath"
+
+if [ -e "$pkgPath/vendor" ];
+then
+    # Enable vendor experiment
+    export GO15VENDOREXPERIMENT=1
+elif [ -e "$pkgPath/Godeps/_workspace" ];
+then
+  # Add local godeps dir to GOPATH
+  GOPATH=$pkgPath/Godeps/_workspace:$GOPATH
+else
+  # Get all package dependencies
+  go get -t -d -v ./...
+fi


### PR DESCRIPTION
Revert changes for testing against subfolders only. 

This brings the testing image up to the same Go version as the build.